### PR TITLE
test: コメントモデル単体テスト#46

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  before_action :logged_in_user, only: [:new, :create, :edit, :destroy]
+  before_action :logged_in_user, only: [:create, :destroy]
 
   def create
     @post = Post.find(params[:post_id])
@@ -10,7 +10,7 @@ class CommentsController < ApplicationController
       @comment_post.create_notification_comment(current_user, @comment.id)
       redirect_to request.referer
     else
-      flash[:alert] = "入力に誤りがあります"
+      flash[:alert] = "コメントが空欄だと投稿できません"
       redirect_to request.referer
     end
   end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :comment do
     association :post
     user { post.user }
-    content { 'a' * 100 }
+    comment { 'a' * 10 }
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  let(:comment) { create(:comment) }
+
+  describe '#create' do
+    context '保存できる場合' do
+
+      it '入力が正しいこと' do
+        expect(comment).to be_valid
+      end
+
+      it '1文字以上であれば保存できること' do
+        comment.comment = 'a' * 1
+        expect(comment).to be_valid
+      end
+
+      it '200文字以内であれば保存できること' do
+        comment.comment = 'a' * 200
+        expect(comment).to be_valid
+      end
+    end
+
+    context '保存できない場合' do
+
+      it '入力が空欄だと保存できない' do
+        comment.comment = ''
+        expect(comment).to be_invalid
+      end
+
+      it '201文字以上だと保存できない' do
+        comment.comment = 'a' * 201
+        expect(comment).to be_invalid
+      end
+
+      it 'post_idがnilだと保存できない' do
+        comment.post_id = nil
+        expect(comment).to be_invalid
+      end
+
+      it 'user_idがnilだと保存できない' do
+        comment.user_id = nil
+        expect(comment).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
why
基幹機能であり保守性を高めるため

why
コメントモデルの単体テスト実装

issue
現状特になし