### PR TITLE
test: ralationshipモデルの単体テスト#48

### DIFF
--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :relationship do
+  end
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+ describe '#create' do
+   let(:user) { create(:user) }
+   let(:other_user) { create(:user) }
+
+   context '正常に保存できる場合' do
+     let(:relationship) {
+       create(
+       :relationship,
+       follower_id: user.id,
+       followed_id: other_user.id
+       )
+     }
+
+      it 'relationshipを登録できること' do
+        expect(relationship).to be_valid
+      end
+    end
+
+    context '保存できない場合' do
+      let(:relationship) {
+        create(
+          :relationship,
+          follower_id: user.id,
+          followed_id: other_user.id
+        )
+      }
+
+      it 'follower_idが存在しないと保存できないこと' do
+        relationship.follower_id = nil
+        expect(relationship).to be_invalid
+      end
+
+      it 'followed_idが存在しないと保存できないこと' do
+        relationship.followed_id = nil
+        expect(relationship).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
 
-  describe '#create' do
+  describe 'create' do
     context 'userを登録できる場合' do
       let(:user) {build(:user)}
 
@@ -93,6 +93,26 @@ RSpec.describe User, type: :model do
       it 'パスワードとパスワード確認が違うと保存できないこと' do
         user.password_confirmation = 'a' * 6
         expect(user).to be_invalid
+      end
+    end
+  end
+
+  describe "follow と unfollow" do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+
+    before { user.follow(other_user) }
+
+    context "他のユーザーをフォローする場合" do
+      it "フォローが保存できること" do
+        expect(user.following?(other_user)).to be_truthy
+      end
+    end
+
+    context "他のユーザーのフォローを解除する場合" do
+      it "フォロー解除が保存できること" do
+        user.unfollow(other_user)
+        expect(user.following?(other_user)).to be_falsy
       end
     end
   end


### PR DESCRIPTION
why
基幹機能にあたり保守性を高めるため

what
ralationshipモデルの単体テスト

issue
特になし