### PR TITLE
test: notificationモデルの単体テスト#51

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,9 +2,9 @@ class NotificationsController < ApplicationController
 
   def index
     @notifications = current_user.passive_notifications
-    @notifications.where(checked: false).each do |notification|
-    notification.update(checked: true)
-    end
+    # @notifications.where(checked: false).each do |notification|
+    # notification.update(checked: true)
+    # end
   end
 
   def destroy

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,4 +1,5 @@
 module NotificationsHelper
+
   def notification_form(notification)
     @visitor = notification.visitor
     @comment = nil
@@ -13,8 +14,7 @@ module NotificationsHelper
       tag.a(@visitor.name, href: user_path(@visitor), class: 'font-bold hover:text-gray-500') + 'さんが' + tag.a('あなたの投稿', href: post_path(notification.post_id), class: 'font-bold hover:text-gray-500') + 'にコメントしました'
     end
   end
-
-  def unchecked_notifications
-    @notifications = current_user.passive_notifications.where(checked: false)
-  end
+  # def unchecked_notifications
+  #   @notifications = current_user.passive_notifications.where(checked: false)
+  # end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,4 +4,5 @@ class Notification < ApplicationRecord
   belongs_to :comment, optional: true
   belongs_to :visitor, class_name: 'User', foreign_key: 'visitor_id', optional: true
   belongs_to :visited, class_name: 'User', foreign_key: 'visited_id', optional: true
+  validates :action, inclusion: { in: %w[like comment follow ]}
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  describe '#create' do
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user) }
+    let(:notification) {
+      build(
+        :notification,
+        visitor_id: user1.id,
+        visited_id: user2.id
+      )
+    }
+
+    describe '正常に保存できる場合' do
+      describe 'likeに関するテスト' do
+        it 'likeを正常に保存できること' do
+          notification.action = 'like'
+          expect(notification).to be_valid
+        end
+      end
+
+      describe 'commentに関するテスト' do
+        it 'commentを正常に保存できること' do
+          notification.action = 'comment'
+          expect(notification).to be_valid
+        end
+      end
+
+      describe 'followに関するテスト' do
+        it 'followを正常に保存できること' do
+          notification.action = 'follow'
+          expect(notification).to be_valid
+        end
+      end
+    end
+
+    describe '正常に保存できない場合' do
+      it 'actionの文字列が指定したもの以外なら保存できないこと' do
+        notification.action = 'aaa'
+        expect(notification).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
why
基幹機能の保守性を高めるため

what
notificationモデルの単体テスト