### PR TITLE
test: DM機能の単体テスト#53

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,4 +1,6 @@
 class Entry < ApplicationRecord
   belongs_to :user
   belongs_to :room
+  validates  :user_id, presence: true, uniqueness: { scope: :room_id }
+  validates  :room_id, presence: true
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,7 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :room
+  validates  :user_id, presence: true
+  validates  :room_id, presence: true
+  validates  :message, presence: true, length: { maximum: 200 }
 end

--- a/app/models/tagmap.rb
+++ b/app/models/tagmap.rb
@@ -1,7 +1,6 @@
 class Tagmap < ApplicationRecord
   belongs_to :post
   belongs_to :tag
-
   validates :post_id, presence: true
   validates :tag_id, presence: true
 end

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :entry do
+    association :user
+    association :room
+  end
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :message do
+    message { 'a' * 200 }
+    association :user
+    association :room
+  end
+end

--- a/spec/factories/room.rb
+++ b/spec/factories/room.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :room do
+    id { 1 }
+  end
+end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Entry, type: :model do
+  describe '#create' do
+    let(:entry) { create(:entry) }
+
+    context 'entry情報が保存できる場合' do
+      it '正常に保存できること' do
+        expect(entry).to be_valid
+      end
+    end
+
+    context 'ebtry情報が保存できない場合' do
+      it 'user_idがないと保存できないこと' do
+        entry.user_id = ''
+        expect(entry).to be_invalid
+      end
+
+      it 'room_idがないと保存できないこと' do
+        entry.user_id = ''
+        expect(entry).to be_invalid
+      end
+    end
+
+    context '一意性のテスト' do
+      it 'user_idとroom_idの組み合わせは一意であること' do
+        example_entry = build(:entry, user_id: entry.user_id, room_id: entry.room_id)
+        expect(example_entry).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  describe '#create' do
+    let(:message) { create(:message) }
+
+    context 'メッセージを保存できる場合' do
+      it '正常に保存できること' do
+        expect(message).to be_valid
+      end
+
+      it 'messageが200文字以内で保存できること' do
+        message.message = 'a' * 200
+        expect(message).to be_valid
+      end
+
+      it 'user_idが違えば同じroom_idで保存できること' do
+        example_user = create(:user)
+        example_message = build(:message,
+                                user_id: example_user.id, room_id: message.room_id)
+        expect(example_message).to be_valid
+      end
+    end
+
+    context 'メッセージを保存できない場合' do
+      it 'user_idがないと保存できないこと' do
+        message.user_id = ''
+        expect(message).to be_invalid
+      end
+
+      it 'room_idがないと保存できないこと' do
+        message.room_id = ''
+        expect(message).to be_invalid
+      end
+
+      it 'messageがないと保存できないこと' do
+        message.message = ''
+        expect(message).to be_invalid
+      end
+
+      it 'messageが200文字以上だと保存できないこと' do
+        message.message = 'a' * 201
+        expect(message).to be_invalid
+      end
+    end
+
+    context '一意性のテスト' do
+      it 'user_idとroom_idの組み合わせが一意であること' do
+        example_message = build(:message)
+        expect(example_message).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
why
基幹機能であり保守性を高めるため

what
DM機能の単体テスト（entry,room,message）

issue
一意性がモデルで担保できてなかったため追記